### PR TITLE
feat: add data cleaning functions to utils.py for reuse

### DIFF
--- a/notebooks/01_eda_baseline.ipynb
+++ b/notebooks/01_eda_baseline.ipynb
@@ -1,0 +1,598 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "language": "python",
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "version": "3.6.4",
+      "file_extension": ".py",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "name": "python",
+      "mimetype": "text/x-python"
+    },
+    "kaggle": {
+      "accelerator": "none",
+      "dataSources": [],
+      "isInternetEnabled": true,
+      "language": "python",
+      "sourceType": "notebook",
+      "isGpuEnabled": false
+    },
+    "colab": {
+      "provenance": [],
+      "include_colab_link": true
+    }
+  },
+  "nbformat_minor": 0,
+  "nbformat": 4,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/TezBytes/music-recommender/blob/feat%2Fdata-cleaning-and-preprocessing/notebooks/01_eda_baseline.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Pre-requisites"
+      ],
+      "metadata": {
+        "id": "1iz8PyWAbmzE"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install kagglehub[pandas-datasets]"
+      ],
+      "metadata": {
+        "id": "EdpsSpbNaryZ",
+        "outputId": "accea29d-dec1-4c6c-81e9-8807f93f764f",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: kagglehub[pandas-datasets] in /usr/local/lib/python3.11/dist-packages (0.3.12)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.11/dist-packages (from kagglehub[pandas-datasets]) (24.2)\n",
+            "Requirement already satisfied: pyyaml in /usr/local/lib/python3.11/dist-packages (from kagglehub[pandas-datasets]) (6.0.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (from kagglehub[pandas-datasets]) (2.32.3)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.11/dist-packages (from kagglehub[pandas-datasets]) (4.67.1)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.11/dist-packages (from kagglehub[pandas-datasets]) (2.2.2)\n",
+            "Requirement already satisfied: numpy>=1.23.2 in /usr/local/lib/python3.11/dist-packages (from pandas->kagglehub[pandas-datasets]) (2.0.2)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.11/dist-packages (from pandas->kagglehub[pandas-datasets]) (2.9.0.post0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas->kagglehub[pandas-datasets]) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas->kagglehub[pandas-datasets]) (2025.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests->kagglehub[pandas-datasets]) (3.4.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests->kagglehub[pandas-datasets]) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests->kagglehub[pandas-datasets]) (2.4.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests->kagglehub[pandas-datasets]) (2025.4.26)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/dist-packages (from python-dateutil>=2.8.2->pandas->kagglehub[pandas-datasets]) (1.17.0)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Load dataset"
+      ],
+      "metadata": {
+        "id": "GlXfihRsbqDN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import kagglehub\n",
+        "from kagglehub import KaggleDatasetAdapter\n",
+        "\n",
+        "file_path = \"dataset.csv\"\n",
+        "\n",
+        "# Load the latest version\n",
+        "df = kagglehub.load_dataset(\n",
+        "  KaggleDatasetAdapter.PANDAS,\n",
+        "  \"maharshipandya/-spotify-tracks-dataset\",\n",
+        "  file_path,\n",
+        ")\n",
+        "\n",
+        "print(\"First 5 records:\", df.head())"
+      ],
+      "metadata": {
+        "id": "6eZcq16GOcx7",
+        "outputId": "04f79c46-1920-4af1-ca57-c1dbd1428ae8",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "<ipython-input-3-9ef33fd9699e>:7: DeprecationWarning: load_dataset is deprecated and will be removed in a future version.\n",
+            "  df = kagglehub.load_dataset(\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "First 5 records:    Unnamed: 0                track_id                 artists  \\\n",
+            "0           0  5SuOikwiRyPMVoIQDJUgSV             Gen Hoshino   \n",
+            "1           1  4qPNDBW1i3p13qLCt0Ki3A            Ben Woodward   \n",
+            "2           2  1iJBSr7s7jYXzM8EGcbK5b  Ingrid Michaelson;ZAYN   \n",
+            "3           3  6lfxq3CG4xtTiEg7opyCyx            Kina Grannis   \n",
+            "4           4  5vjLSffimiIP26QG5WcN2K        Chord Overstreet   \n",
+            "\n",
+            "                                          album_name  \\\n",
+            "0                                             Comedy   \n",
+            "1                                   Ghost (Acoustic)   \n",
+            "2                                     To Begin Again   \n",
+            "3  Crazy Rich Asians (Original Motion Picture Sou...   \n",
+            "4                                            Hold On   \n",
+            "\n",
+            "                   track_name  popularity  duration_ms  explicit  \\\n",
+            "0                      Comedy          73       230666     False   \n",
+            "1            Ghost - Acoustic          55       149610     False   \n",
+            "2              To Begin Again          57       210826     False   \n",
+            "3  Can't Help Falling In Love          71       201933     False   \n",
+            "4                     Hold On          82       198853     False   \n",
+            "\n",
+            "   danceability  energy  ...  loudness  mode  speechiness  acousticness  \\\n",
+            "0         0.676  0.4610  ...    -6.746     0       0.1430        0.0322   \n",
+            "1         0.420  0.1660  ...   -17.235     1       0.0763        0.9240   \n",
+            "2         0.438  0.3590  ...    -9.734     1       0.0557        0.2100   \n",
+            "3         0.266  0.0596  ...   -18.515     1       0.0363        0.9050   \n",
+            "4         0.618  0.4430  ...    -9.681     1       0.0526        0.4690   \n",
+            "\n",
+            "   instrumentalness  liveness  valence    tempo  time_signature  track_genre  \n",
+            "0          0.000001    0.3580    0.715   87.917               4     acoustic  \n",
+            "1          0.000006    0.1010    0.267   77.489               4     acoustic  \n",
+            "2          0.000000    0.1170    0.120   76.332               4     acoustic  \n",
+            "3          0.000071    0.1320    0.143  181.740               3     acoustic  \n",
+            "4          0.000000    0.0829    0.167  119.949               4     acoustic  \n",
+            "\n",
+            "[5 rows x 21 columns]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(df.shape)"
+      ],
+      "metadata": {
+        "id": "pqrolelXazD2",
+        "outputId": "ebfba25c-15ef-45f8-85a4-42419722a017",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "(114000, 21)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(df.head)"
+      ],
+      "metadata": {
+        "id": "uBxqmVq8bbKc",
+        "outputId": "26002a72-1806-4dd1-bdb8-6b69946c267e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<bound method NDFrame.head of         Unnamed: 0                track_id                 artists  \\\n",
+            "0                0  5SuOikwiRyPMVoIQDJUgSV             Gen Hoshino   \n",
+            "1                1  4qPNDBW1i3p13qLCt0Ki3A            Ben Woodward   \n",
+            "2                2  1iJBSr7s7jYXzM8EGcbK5b  Ingrid Michaelson;ZAYN   \n",
+            "3                3  6lfxq3CG4xtTiEg7opyCyx            Kina Grannis   \n",
+            "4                4  5vjLSffimiIP26QG5WcN2K        Chord Overstreet   \n",
+            "...            ...                     ...                     ...   \n",
+            "113995      113995  2C3TZjDRiAzdyViavDJ217           Rainy Lullaby   \n",
+            "113996      113996  1hIz5L4IB9hN3WRYPOCGPw           Rainy Lullaby   \n",
+            "113997      113997  6x8ZfSoqDjuNa5SVP5QjvX           Cesária Evora   \n",
+            "113998      113998  2e6sXL2bYv4bSz6VTdnfLs        Michael W. Smith   \n",
+            "113999      113999  2hETkH7cOfqmz3LqZDHZf5           Cesária Evora   \n",
+            "\n",
+            "                                               album_name  \\\n",
+            "0                                                  Comedy   \n",
+            "1                                        Ghost (Acoustic)   \n",
+            "2                                          To Begin Again   \n",
+            "3       Crazy Rich Asians (Original Motion Picture Sou...   \n",
+            "4                                                 Hold On   \n",
+            "...                                                   ...   \n",
+            "113995  #mindfulness - Soft Rain for Mindful Meditatio...   \n",
+            "113996  #mindfulness - Soft Rain for Mindful Meditatio...   \n",
+            "113997                                            Best Of   \n",
+            "113998                                  Change Your World   \n",
+            "113999                                     Miss Perfumado   \n",
+            "\n",
+            "                        track_name  popularity  duration_ms  explicit  \\\n",
+            "0                           Comedy          73       230666     False   \n",
+            "1                 Ghost - Acoustic          55       149610     False   \n",
+            "2                   To Begin Again          57       210826     False   \n",
+            "3       Can't Help Falling In Love          71       201933     False   \n",
+            "4                          Hold On          82       198853     False   \n",
+            "...                            ...         ...          ...       ...   \n",
+            "113995         Sleep My Little Boy          21       384999     False   \n",
+            "113996            Water Into Light          22       385000     False   \n",
+            "113997              Miss Perfumado          22       271466     False   \n",
+            "113998                     Friends          41       283893     False   \n",
+            "113999                   Barbincor          22       241826     False   \n",
+            "\n",
+            "        danceability  energy  ...  loudness  mode  speechiness  acousticness  \\\n",
+            "0              0.676  0.4610  ...    -6.746     0       0.1430        0.0322   \n",
+            "1              0.420  0.1660  ...   -17.235     1       0.0763        0.9240   \n",
+            "2              0.438  0.3590  ...    -9.734     1       0.0557        0.2100   \n",
+            "3              0.266  0.0596  ...   -18.515     1       0.0363        0.9050   \n",
+            "4              0.618  0.4430  ...    -9.681     1       0.0526        0.4690   \n",
+            "...              ...     ...  ...       ...   ...          ...           ...   \n",
+            "113995         0.172  0.2350  ...   -16.393     1       0.0422        0.6400   \n",
+            "113996         0.174  0.1170  ...   -18.318     0       0.0401        0.9940   \n",
+            "113997         0.629  0.3290  ...   -10.895     0       0.0420        0.8670   \n",
+            "113998         0.587  0.5060  ...   -10.889     1       0.0297        0.3810   \n",
+            "113999         0.526  0.4870  ...   -10.204     0       0.0725        0.6810   \n",
+            "\n",
+            "        instrumentalness  liveness  valence    tempo  time_signature  \\\n",
+            "0               0.000001    0.3580   0.7150   87.917               4   \n",
+            "1               0.000006    0.1010   0.2670   77.489               4   \n",
+            "2               0.000000    0.1170   0.1200   76.332               4   \n",
+            "3               0.000071    0.1320   0.1430  181.740               3   \n",
+            "4               0.000000    0.0829   0.1670  119.949               4   \n",
+            "...                  ...       ...      ...      ...             ...   \n",
+            "113995          0.928000    0.0863   0.0339  125.995               5   \n",
+            "113996          0.976000    0.1050   0.0350   85.239               4   \n",
+            "113997          0.000000    0.0839   0.7430  132.378               4   \n",
+            "113998          0.000000    0.2700   0.4130  135.960               4   \n",
+            "113999          0.000000    0.0893   0.7080   79.198               4   \n",
+            "\n",
+            "        track_genre  \n",
+            "0          acoustic  \n",
+            "1          acoustic  \n",
+            "2          acoustic  \n",
+            "3          acoustic  \n",
+            "4          acoustic  \n",
+            "...             ...  \n",
+            "113995  world-music  \n",
+            "113996  world-music  \n",
+            "113997  world-music  \n",
+            "113998  world-music  \n",
+            "113999  world-music  \n",
+            "\n",
+            "[114000 rows x 21 columns]>\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Drop Duplicates on track_id"
+      ],
+      "metadata": {
+        "id": "z0R5p67obfYN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "df.drop_duplicates(subset=['track_id'], inplace=True)"
+      ],
+      "metadata": {
+        "id": "QA2GDP8Kbcr4"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(f\"After dropping duplicates: {df.shape}\")"
+      ],
+      "metadata": {
+        "id": "xZuC310vb052",
+        "outputId": "6da8c6fa-5b6b-4269-f2ff-b1bc984ad3bb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "After dropping duplicates: (89741, 21)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Remove Rows with Missing Elements"
+      ],
+      "metadata": {
+        "id": "DysZ_rdMcCTy"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "req_cols = [\"track_name\",\"danceability\", \"energy\", \"track_id\" ]\n",
+        "df.dropna(subset=req_cols, inplace=True)"
+      ],
+      "metadata": {
+        "id": "ZwnXRu2Yb9N8"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(f\"After dropping missing values: {df.shape}\")"
+      ],
+      "metadata": {
+        "id": "FmNsE77tcwV2",
+        "outputId": "d604e69f-6da6-4263-e4fc-731c66220a84",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "After dropping missing values: (89740, 21)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Convert Data Types"
+      ],
+      "metadata": {
+        "id": "jQ9dzvzpc0wD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "df[\"explicit\"] = df[\"explicit\"].astype(bool)\n",
+        "df[\"duration_sec\"] = df[\"duration_ms\"] / 1000\n",
+        "df[\"duration_sec\"] = df[\"duration_sec\"].astype(int)"
+      ],
+      "metadata": {
+        "id": "BxBdnju4cy6x"
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Normalize Numerical Features"
+      ],
+      "metadata": {
+        "id": "WxZvSd9UdSeU"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from sklearn.preprocessing import MinMaxScaler\n",
+        "\n",
+        "num_cols = [\"danceability\", \"energy\", \"duration_sec\"]\n",
+        "scaler = MinMaxScaler()\n",
+        "df[num_cols] = scaler.fit_transform(df[num_cols])"
+      ],
+      "metadata": {
+        "id": "hYfCGUQVdOQ7"
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Save Cleaned Data"
+      ],
+      "metadata": {
+        "id": "93QImo3uds2z"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.path.exists(\"data\"):\n",
+        "    os.makedirs(\"data\")\n",
+        "    print(\"Directory 'data' created successfully.\")\n",
+        "else:\n",
+        "    print(\"Directory 'data' already exists.\")"
+      ],
+      "metadata": {
+        "id": "4Dx8o-YVeA4w",
+        "outputId": "10c6ab5e-50d7-420b-99a5-3c0c7772d4c7",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Directory 'data' already exists.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "df.to_csv(\"data/enriched_data.csv\", index=False)"
+      ],
+      "metadata": {
+        "id": "4Gp4WWKadrgF"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Write to utils.py"
+      ],
+      "metadata": {
+        "id": "XhzC8UfIhViL"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "\n",
+        "# Make sure the folder exists\n",
+        "os.makedirs(\"scripts\", exist_ok=True)\n",
+        "\n",
+        "# Create empty utils.py\n",
+        "with open(\"scripts/utils.py\", \"w\") as f:\n",
+        "    f.write(\"\")  # just creates the file"
+      ],
+      "metadata": {
+        "id": "xTM6NE4uhbT-"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "utils_code = \"\"\"\n",
+        "import pandas as pd\n",
+        "from sklearn.preprocessing import MinMaxScaler\n",
+        "\n",
+        "def load_dataset(path):\n",
+        "    df = pd.read_csv(path)\n",
+        "    return df\n",
+        "\n",
+        "def drop_duplicates(df, subset_col=\"track_id\"):\n",
+        "    return df.drop_duplicates(subset=subset_col)\n",
+        "\n",
+        "def clean_missing_values(df, required_cols):\n",
+        "    return df.dropna(subset=required_cols)\n",
+        "\n",
+        "def convert_types(df):\n",
+        "    df[\"explicit\"] = df[\"explicit\"].astype(bool)\n",
+        "    df[\"duration_sec\"] = df[\"duration_ms\"] / 1000\n",
+        "    return df.drop(columns=[\"duration_ms\"])\n",
+        "\n",
+        "def normalize_features(df, cols):\n",
+        "    scaler = MinMaxScaler()\n",
+        "    df[cols] = scaler.fit_transform(df[cols])\n",
+        "    return df\n",
+        "\"\"\"\n",
+        "\n",
+        "with open(\"scripts/utils.py\", \"w\") as f:\n",
+        "    f.write(utils_code)"
+      ],
+      "metadata": {
+        "id": "pscMoKpBhgBS"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Use in notebook"
+      ],
+      "metadata": {
+        "id": "oo-1Sf8Yhyw-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import sys\n",
+        "sys.path.append(\"scripts\")\n",
+        "\n",
+        "import utils\n",
+        "\n",
+        "df = utils.load_dataset(\"data/enriched_data.csv\")"
+      ],
+      "metadata": {
+        "id": "XhfYDDqChqcv"
+      },
+      "execution_count": 21,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(df.shape)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "uHLsSFAgh2Oz",
+        "outputId": "1c4e259f-d2ca-4397-b1d9-4bba38c728e2"
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "(89740, 22)\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 🔧 Pull Request: Issue #2 – Data Cleaning & Preprocessing

### ✅ Changes Made
- Abstracted cleaning logic from `01_eda_baseline.ipynb` into `scripts/utils.py`
- Implemented modular cleaning steps: duplicate removal, null filtering, type conversion, and normalization
- Converted `duration_ms` to `duration_sec` and cast `explicit` to boolean
- Saved the cleaned dataset as `enriched_data.csv` for consistent reuse

### 📂 Access Preprocessed Dataset
- [`enriched_data.csv` on Hugging Face](https://huggingface.co/datasets/tezbytes/music-recommender-data)

### 🛠️ Utility Additions (`utils.py`)
- `load_dataset(path)` – Load a CSV into a DataFrame
- `drop_duplicates(df, subset_col)` – Remove duplicate rows based on `track_id`
- `clean_missing_values(df, required_cols)` – Drop rows with nulls in specified columns
- `convert_types(df)` – Convert types and compute derived duration column
- `normalize_features(df, cols)` – Min-max normalize numerical feature columns

### 🎯 Outcome
- Establishes a reusable data cleaning pipeline
- Decouples preprocessing from notebooks, improving maintainability
- Lays foundation for consistent enrichment and model training workflows